### PR TITLE
fix: wrong array-mode context key

### DIFF
--- a/templates/go/go.go
+++ b/templates/go/go.go
@@ -2151,7 +2151,7 @@ func Uint32(ctx context.Context) string {
 
 // ArrayMode returns array-mode from the context.
 func ArrayMode(ctx context.Context) string {
-	s, _ := ctx.Value(ArrayMode).(string)
+	s, _ := ctx.Value(ArrayModeKey).(string)
 	return s
 }
 


### PR DESCRIPTION
Fixed incorrect key for getting ArrayMode from context.