### PR TITLE
Fix missing space before table alias in generated Upsert function for oracle

### DIFF
--- a/templates/go/go.go
+++ b/templates/go/go.go
@@ -1641,7 +1641,7 @@ func (f *Funcs) sqlstr_upsert_sqlserver_oracle(v interface{}) []string {
 		case "sqlserver":
 			lines = []string{"MERGE " + f.schemafn(x.SQLName) + " AS t "}
 		case "oracle":
-			lines = []string{"MERGE " + f.schemafn(x.SQLName) + "t "}
+			lines = []string{"MERGE " + f.schemafn(x.SQLName) + " t "}
 		}
 		// using (select ..)
 		var fields, predicate []string


### PR DESCRIPTION
This PR fixes an issue with the generated Upsert function for Oracle databases. The generated MERGE statement was missing a space before the table alias (t), which resulted in invalid SQL.

**Changes Made:**
- Added a space before the table alias (t) in the generated MERGE statement for Upsert.

Fixes #416 
