### PR TITLE
fix: remove deprecated VendorlessPath reference for fix go 1.25 build errors

### DIFF
--- a/internal/golang_org-x-tools-imports.go
+++ b/internal/golang_org-x-tools-imports.go
@@ -10,10 +10,9 @@ import (
 func init() {
 	Symbols["golang.org/x/tools/imports/imports"] = map[string]reflect.Value{
 		// function, constant and variable definitions
-		"Debug":          reflect.ValueOf(&imports.Debug).Elem(),
-		"LocalPrefix":    reflect.ValueOf(&imports.LocalPrefix).Elem(),
-		"Process":        reflect.ValueOf(imports.Process),
-		"VendorlessPath": reflect.ValueOf(imports.VendorlessPath),
+		"Debug":       reflect.ValueOf(&imports.Debug).Elem(),
+		"LocalPrefix": reflect.ValueOf(&imports.LocalPrefix).Elem(),
+		"Process":     reflect.ValueOf(imports.Process),
 
 		// type definitions
 		"Options": reflect.ValueOf((*imports.Options)(nil)),


### PR DESCRIPTION
## Summary
This PR fixes build failures with Go 1.25+ by removing the reference to the deprecated `VendorlessPath` function from `golang.org/x/tools/imports`.

## Problem
The `VendorlessPath` function was removed from `golang.org/x/tools/imports` in newer versions, causing build errors:
```
# github.com/xo/dbtpl/internal
internal/golang_org-x-tools-imports.go:16:45: undefined: imports.VendorlessPath
```

## Solution
Removed the deprecated `VendorlessPath` reference from the auto-generated `internal/golang_org-x-tools-imports.go` file.


## Files Changed
- `internal/golang_org-x-tools-imports.go`: Removed VendorlessPath reference