### PR TITLE
Ensure consistent ordering of Postgres enum values

### DIFF
--- a/models/enumvalue.dbtpl.go
+++ b/models/enumvalue.dbtpl.go
@@ -22,7 +22,8 @@ func PostgresEnumValues(ctx context.Context, db DB, schema, enum string) ([]*Enu
 		`JOIN ONLY pg_namespace n ON n.oid = t.typnamespace ` +
 		`LEFT JOIN pg_enum e ON t.oid = e.enumtypid ` +
 		`WHERE n.nspname = $1 ` +
-		`AND t.typname = $2`
+		`AND t.typname = $2 ` +
+		`ORDER BY e.enumsortorder`
 	// run
 	logf(sqlstr, schema, enum)
 	rows, err := db.QueryContext(ctx, sqlstr, schema, enum)


### PR DESCRIPTION
Closes #429.

As discussed in the issue above, Postgres does not _guarantee_ the ordering of enum values returned by the query in `models/enumvalue.dbtpl.go`: the migrations leading the the final schema may leave those rows in different orders.

An explicit ordering in the statement ensures that regardless of the history and state of the internal `pg_type` table, the output is always consistent for a given schema.

The output from dbtpl may be different after this change gets introduced, but it would then remain consistent afterwards.