### PR TITLE
gen.sh: fix NULL scan errors and schema leak in proc introspection

### DIFF
--- a/gen.sh
+++ b/gen.sh
@@ -354,7 +354,7 @@ SELECT
   LOWER(r.routine_type) AS proc_type,
   COALESCE(p.dtd_identifier, 'void') AS return_type,
   COALESCE(p.parameter_name, '') AS return_name,
-  r.routine_definition AS proc_def
+  COALESCE(r.routine_definition, '') AS proc_def
 FROM information_schema.routines r
   LEFT JOIN information_schema.parameters p ON p.specific_schema = r.routine_schema
     AND p.specific_name = r.routine_name
@@ -616,12 +616,12 @@ SELECT
       THEN SUBSTRING(p.name, 2, LEN(p.name)-1)
     ELSE ''
   END AS return_name,
-  OBJECT_DEFINITION(o.object_id) AS proc_def
+  COALESCE(OBJECT_DEFINITION(o.object_id), '') AS proc_def
 FROM sys.objects o
   LEFT JOIN sys.parameters p ON o.object_id = p.object_id
     AND (p.object_id IS NULL OR p.is_output = 'true')
-WHERE o.type = 'P'
-   OR o.type = 'FN'
+WHERE (o.type = 'P' OR o.type = 'FN')
+  AND o.is_ms_shipped = 0
   AND SCHEMA_NAME(o.schema_id) = %%schema string%%
 ORDER BY o.object_id
 ENDSQL


### PR DESCRIPTION
**NB:** This PR modifies `gen.sh` only. The committed generated Go files under `models/` need to be regenerated by a maintainer with access to the bootstrap PG/MySQL/MSSQL/SQLite/Oracle instances.

---

The generated `Proc` struct scans `proc_def` into a plain Go string, so any NULL value from the introspection query fails with:

```
sql: Scan error on column index 5, name "proc_def": converting NULL to string is unsupported
```

**SqlserverProcs:**
- Wrap `OBJECT_DEFINITION(o.object_id)` in `COALESCE(..., '')`. Returns NULL for MS-shipped, encrypted, and CLR/extended procs (#431).
- Fix WHERE-clause operator precedence: `type='P' OR type='FN' AND schema=...` parses as `type='P' OR (type='FN' AND schema=...)`, so every `type='P'` proc in every schema leaks in. Parenthesize the type check and also filter `is_ms_shipped = 0` to drop the ~31 MS-shipped procs in `dbo`.

**MysqlProcs:**
- Wrap `r.routine_definition` in `COALESCE(..., '')`. `information_schema.routines.routine_definition` is NULL when the connecting user lacks `SHOW_ROUTINE` (common on RDS) (#370). The same query already COALESCEs two adjacent columns; this one was missed.

MSSQL NULL object_id fix was tested against a local database with a repro using a local build.   The other changes have not been tested. 

Closes #431
Refs #370