### PR TITLE
templates/go: disambiguate fields from digit-prefixed SQL columns

### DIFF
--- a/templates/go/go.go
+++ b/templates/go/go.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
+	"unicode"
 
 	"github.com/kenshaw/inflector"
 	"github.com/kenshaw/snaker"
@@ -727,9 +728,24 @@ func convertField(ctx context.Context, tf transformFunc, f xo.Field) (Field, err
 	if err != nil {
 		return Field{}, err
 	}
+	goName := tf(f.Name)
+	// Disambiguate names whose leading digits get stripped by the identifier
+	// sanitizer: a column "1X" and "2X" both collapse to "X" otherwise.
+	if len(f.Name) > 0 && f.Name[0] >= '0' && f.Name[0] <= '9' {
+		// Sanitize characters that are legal in SQL but not Go, as snaker would
+		// have. Matches the Go spec's identifier rune class (Unicode letters,
+		// digits, underscore).
+		safe := strings.Map(func(r rune) rune {
+			if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' {
+				return r
+			}
+			return '_'
+		}, f.Name)
+		goName = goName + "_" + safe
+	}
 	return Field{
 		Type:       typ,
-		GoName:     tf(f.Name),
+		GoName:     goName,
 		SQLName:    f.Name,
 		Zero:       zero,
 		IsPrimary:  f.IsPrimary,


### PR DESCRIPTION
## Summary

- Columns like `1X`, `2X`, `3X` all collapse to a single Go field `X` because `snaker.ForceCamelIdentifier` strips leading digits — generating structs with duplicate fields that fail to compile.
- Fix: when a SQL column name starts with a digit, append `_<sanitized original>` to the generated `GoName` (e.g. `1X` → `X_1X`, `2X` → `X_2X`).
- Sanitization of the appended original matches the current snaker identifier rune class (Unicode letters, digits, underscore), which in turn matches the Go language spec.

Fixes #433.

Tested against an MSSQL repro of the issue with a local build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)