### PR TITLE
Map MSSQL uniqueidentifier to google/uuid

### DIFF
--- a/loader/sqlserver.go
+++ b/loader/sqlserver.go
@@ -67,6 +67,12 @@ func SqlserverGoType(d xo.Type, schema, itype, utype string) (string, string, er
 		}
 	case "binary", "image", "varbinary", "xml":
 		goType, zero = "[]byte", "nil"
+	case "uniqueidentifier":
+		// mssql.UniqueIdentifier was an alternative, but it would tie generated code to the go-mssqldb driver.
+		goType, zero = "uuid.UUID", "uuid.UUID{}"
+		if d.Nullable {
+			goType, zero = "uuid.NullUUID", "uuid.NullUUID{}"
+		}
 	case "date", "time", "smalldatetime", "datetime", "datetime2", "datetimeoffset":
 		goType, zero = "time.Time", "time.Time{}"
 		if d.Nullable {


### PR DESCRIPTION
## Summary

- MSSQL `uniqueidentifier` columns previously fell through `SqlserverGoType` to `schemaType`, generating a placeholder `Uniqueidentifier` struct name in user code.
- Map them instead to `uuid.UUID` / `uuid.NullUUID`, mirroring the postgres `uuid` mapping at `loader/postgres.go:165` and reusing the existing `--uuid` flag and import wiring (`templates/go/go.go:143`, `:2194`, `:2034`).
- `mssql.UniqueIdentifier` (from `github.com/microsoft/go-mssqldb`) was considered but rejected to avoid introducing a new dependency when `google/uuid` is already available from the postgres path.

Fixes #435.

Tested against an MSSQL repro of the issue with a local build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)