### PR TITLE
chore: upgrade GitHub Actions versions to latest releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,9 @@ jobs:
           libc6-dev-arm64-cross \
           file
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
     - name: Setup Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ env.GO_VERSION }}
     - name: Build ${{ matrix.arch }}
@@ -43,7 +43,7 @@ jobs:
       run: |
         ./build.sh -v $VER -a ${{ matrix.arch }} -s
     - name: Archive artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v7
       with:
         name: dist-linux-${{ matrix.arch }}
         path: build/linux/**/*
@@ -60,16 +60,16 @@ jobs:
       run: |
         brew install coreutils gnu-tar
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
     - name: Setup Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ env.GO_VERSION }}
     - name: Build ${{ matrix.arch }}
       run: |
         ./build.sh -v $VER -a ${{ matrix.arch }}
     - name: Archive artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v7
       with:
         name: dist-darwin-${{ matrix.arch }}
         path: build/darwin/**/*
@@ -85,7 +85,7 @@ jobs:
       run: |
         brew install coreutils gnu-tar
     - name: Download artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v8
     - name: Build universal
       run: |
         export WORKDIR=$PWD/build/darwin/universal/$VER
@@ -112,7 +112,7 @@ jobs:
         ls -alh $WORKDIR/*
         sha256sum $WORKDIR/*
     - name: Archive artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v7
       with:
         name: dist-darwin-universal
         path: build/darwin/**/*
@@ -125,9 +125,9 @@ jobs:
     - name: Install build dependencies
       run: choco install zip
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
     - name: Setup Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ env.GO_VERSION }}
     - name: Build amd64
@@ -135,7 +135,7 @@ jobs:
       run: |
         ./build.sh -v $VER
     - name: Archive artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v7
       with:
         name: dist-windows
         path: build/windows/**/*
@@ -151,9 +151,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v8
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         if: startsWith(github.ref, 'refs/tags/v')
         with:
           name: ${{ env.APP }} ${{ env.VER }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: stable
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
     - name: Build
       run: go build ./...


### PR DESCRIPTION
I saw that the latest CI run failed due to deprecated action versions, so I updated the GitHub Actions to their latest versions.